### PR TITLE
Use page order instead of enumeration

### DIFF
--- a/src/bin/fetch_volume.rs
+++ b/src/bin/fetch_volume.rs
@@ -54,11 +54,14 @@ fn main() -> anyhow::Result<()> {
     let volume_str = create_volume_metadata(&volume, &config.output_dir)
         .context("failed to create volume metadata")?;
 
-    for (idx, page) in pages.iter().enumerate() {
-        let next_slug = if idx == pages.len() - 1 {
+    let mut sorted_pages: Vec<&PageData> = pages.iter().collect();
+    sorted_pages.sort_by_key(|page| page.order);
+    
+    for (idx, page) in sorted_pages.iter().enumerate() {
+        let next_slug = if idx == sorted_pages.len() - 1 {
             None
         } else {
-            Some(pages[idx + 1].slug.as_str())
+            Some(sorted_pages[idx + 1].slug.as_str())
         };
         if let Err(e) = create_page(page, &config.output_dir, next_slug) {
             eprintln!("Error writing page {}: {}", page.slug, e);

--- a/src/cms/fetch.rs
+++ b/src/cms/fetch.rs
@@ -157,11 +157,14 @@ pub fn collect_pages(resp: &VolumeData) -> anyhow::Result<Vec<PageData>> {
                 })
                 .collect();
 
+            let order: usize = 
+                get_attribute(page, "Order").context(format!("page '{}' must have an Order", &title))?;
+
             Ok(PageData {
                 title: title.to_string(),
                 slug,
                 parent,
-                order: index,
+                order,
                 assignments,
                 quiz,
                 chunks: chunks.context("failed to parse chunk")?,


### PR DESCRIPTION
Issue:
- Original code was using enumeration for page order instead of the pages' `Order` attribute, meaning that any page with an update would be automatically sent to the bottom of the pile.

Fix:
- Updated `fetch.rs` to fetch page `Order` from Strapi. 
- Updated `fetch_volume.rs ` to use the fetched page order.